### PR TITLE
see editorState in Detail Page

### DIFF
--- a/src/api/post/index.js
+++ b/src/api/post/index.js
@@ -49,7 +49,6 @@ const getConvertToRawPost = postContent => {
 const getConvertFromRawPost = rawPostContent => ({
   ...rawPostContent,
   editorState: EditorState.createWithContent(
-    convertFromRaw(JSON.parse(rawPostContent.editorState)),
-    compositeDecorator
+    convertFromRaw(JSON.parse(rawPostContent.editorState))
   )
 });

--- a/src/pages/PostDetail/index.js
+++ b/src/pages/PostDetail/index.js
@@ -4,6 +4,7 @@ import { useDispatch, useSelector } from "react-redux";
 import { MyEditor } from "components";
 import Helmet from "components/Helmet";
 import { actions, selectors } from "data";
+import { useEditorState } from "components/MyEditor/hooks";
 
 export default function PostDetailComp({ match }) {
   const dispatch = useDispatch();
@@ -15,6 +16,7 @@ export default function PostDetailComp({ match }) {
   const title = useSelector(selectors.post.getTitle);
   const subTitle = useSelector(selectors.post.getSubTitle);
   const id = userSession?.id;
+  const [editorState, setEditorState] = useEditorState(id);
 
   useEffect(() => {
     dispatch(actions.post.getOnePostDetail(postId));
@@ -29,8 +31,8 @@ export default function PostDetailComp({ match }) {
     <>
       <Helmet title={title} description={subTitle} />
       <MyEditor
-        editorState={currentPost.editorState}
-        setEditorState={() => {}}
+        editorState={editorState}
+        setEditorState={setEditorState}
         readOnly={true}
         id={id}
       />


### PR DESCRIPTION
1. 
detail page 에서 참조하는 editorState 를 
redux 의 
currentPost 에서 가지고오지 않고, 
editorState 에서 가지고 왔다.

2. 
useEditorState 를 detail page 에도 적용해서, setEditorState 를 제대로 넣어줫다. 

3. 
decorator 가 제대로 되는것을 볼수있다. 

결론. 
decorator 는 내부적으로 setEditorState 를 사용한다. 
이전에 비어있는 function 이었어서 제대로 작동하지 않았던것. 